### PR TITLE
Add firewall rules for Azure Monitor Agent and Docker registry

### DIFF
--- a/firewall-rules/acdc/rules.yaml
+++ b/firewall-rules/acdc/rules.yaml
@@ -1,0 +1,13 @@
+landing_zone_id: acdc
+application_rules:
+  - description: Firewall rules for Azure Monitor Agent and Docker container registry access
+    comment: Includes endpoints for Azure Monitor Agent and Docker registry
+    target_fqdns:
+      - dc.services.visualstudio.com
+      - ods.opinsights.azure.com
+      - monitoringagent.blob.core.windows.net
+      - global.azure-devices-provisioning.net
+      - mcr.microsoft.com
+      - '*.data.mcr.microsoft.com'
+    protocol_port:
+      - Https:443


### PR DESCRIPTION
This PR adds firewall rules for the landing zone 'acdc' to allow Azure Monitor Agent and Docker container registry access.